### PR TITLE
Update outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -31,3 +31,8 @@ output "service_account_key" {
   value       = local.service_account_key
   sensitive   = true
 }
+
+output "vpc_network_name" {
+  description = "The name of the VPC network created for Reducto"
+  value       = module.network.network_name
+}


### PR DESCRIPTION
Add vpc_network_name to outputs for use downstream. Useful for serverless applications (cloud run) where VPC serverless connector is required.