### PR TITLE
Adding ingress ILB name to output

### DIFF
--- a/helm-release.tf
+++ b/helm-release.tf
@@ -35,7 +35,7 @@ resource "helm_release" "reducto" {
 
   chart   = var.reducto_helm_chart_oci
   version = var.reducto_helm_chart_version
-  wait    = false
+  wait    = true
 
   values = [
     "${file("values/reducto.yaml")}",
@@ -69,7 +69,7 @@ resource "helm_release" "reducto" {
 
 data "kubernetes_ingress" "ingress" {
   metadata {
-    name = "reducto-reducto-http-ingress"
+    name = "${helm_release.reducto.name}-reducto-http-ingress"
   }
   depends_on = [helm_release.reducto]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,5 +39,5 @@ output "vpc_network_name" {
 
 output "ingress_forwarding_rule_name" {
   description = "The name of the forwarding rule created for reducto via k8s ingress"
-  value = data.kubernetes_ingress.ingress.metadata.annotations["ingress.kubernetes.io/forwarding-rule"]
+  value = lookup(data.kubernetes_ingress.ingress.metadata.annotations, "ingress.kubernetes.io/forwarding-rule", null)
 }


### PR DESCRIPTION
Exposes the name of the internal load balancer created via k8s ingress as an output from the module. This could then be used to automate private networking component creation