### PR TITLE
feat: support for workload identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ terraform apply
 
 Ensure that domain name in `var.reducto_host` resolves to IP of internal load balancer of Reducto Ingress.
 
+### FQDN Network Policy and Workload Identity
+
+When using `FQDNNetworkPolicy` you must allow `name: metadata.google.internal` when Workload Identity is enabled via `var.workload_identity=true`.
+
 ### Notes on Destroy
 
 To delete, set `deletion_protection = false` and run `terraform destroy`. You may get following error, to resolve it manually delete from VPC under "VPC network peering" tab, and rerun `terraform destroy`.

--- a/gke.tf
+++ b/gke.tf
@@ -18,6 +18,10 @@ module "gke" {
   remove_default_node_pool  = true
   deletion_protection       = var.deletion_protection
 
+  # Dataplane V2 and FQDN Network policy
+  datapath_provider          = "ADVANCED_DATAPATH"
+  enable_fqdn_network_policy = true
+
   node_pools = concat([
     {
       name              = "reducto-c2d-highcpu-8"

--- a/service-account.tf
+++ b/service-account.tf
@@ -28,3 +28,28 @@ locals {
   service_account_key      = base64decode(google_service_account_key.service_account_key.private_key)
   service_account_key_json = jsonencode(local.service_account_key)
 }
+
+resource "google_project_iam_member" "service_account_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+## WORKLOAD IDENTITY
+# Docs: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iam
+
+resource "google_project_iam_member" "service_usage_consumer" {
+  # for vision.googleapis.com
+  count   = var.workload_identity ? 1 : 0
+  project = var.project_id
+  role    = "roles/serviceusage.serviceUsageConsumer"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+
+resource "google_service_account_iam_member" "workload_identity_user" {
+  count              = var.workload_identity ? 1 : 0
+  service_account_id = google_service_account.service_account.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${local.namespace_name}/${local.release_name}-reducto]"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -162,3 +162,8 @@ variable "extra_node_pools" {
 
   default = []
 }
+
+variable "workload_identity" {
+  description = "Whether to use workload identity"
+  default     = false
+}


### PR DESCRIPTION
Allow opt-int for Workload Identity via `var.workload_identity` and Terraform sets the correct configuration for Helm Release.

Miscellaneous:  For GKE setup Dataplane V2 and FQDN Network policy (required for `FQDNNetworkPolicy`)