### PR TITLE
Use regional `total_min_count` and `total_max_count` instead zonal `min_count` and `max_count`

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -14,6 +14,7 @@ module "gke" {
   create_service_account    = true
   enable_private_endpoint   = false
   enable_private_nodes      = true
+  enable_cost_allocation    = true
   default_max_pods_per_node = 20
   remove_default_node_pool  = true
   deletion_protection       = var.deletion_protection
@@ -35,7 +36,7 @@ module "gke" {
     {
       name              = "reducto-secondary-node-pool"
       machine_type      = var.secondary_machine_type
-      min_count         = 1
+      min_count         = 0
       max_count         = 100
       local_ssd_count   = 1
       disk_size_gb      = 100

--- a/gke.tf
+++ b/gke.tf
@@ -23,8 +23,9 @@ module "gke" {
     {
       name              = "reducto-primary-node-pool"
       machine_type      = var.primary_machine_type
-      min_count         = 1
-      max_count         = 100
+      total_min_count   = 2
+      total_max_count   = 100
+      location_policy   = "BALANCED"
       local_ssd_count   = 1
       disk_size_gb      = 100
       disk_type         = "pd-ssd"
@@ -36,8 +37,9 @@ module "gke" {
     {
       name              = "reducto-secondary-node-pool"
       machine_type      = var.secondary_machine_type
-      min_count         = 0
-      max_count         = 100
+      total_min_count   = 1
+      total_max_count   = 100
+      location_policy   = "BALANCED"
       local_ssd_count   = 1
       disk_size_gb      = 100
       disk_type         = "pd-ssd"
@@ -49,8 +51,9 @@ module "gke" {
     {
       name              = "reducto-secondary-node-pool-preemptible"
       machine_type      = var.secondary_machine_type
-      min_count         = 0
-      max_count         = 100
+      total_min_count   = 0
+      total_max_count   = 100
+      location_policy   = "BALANCED"
       local_ssd_count   = 1
       disk_size_gb      = 100
       disk_type         = "pd-ssd"


### PR DESCRIPTION
Allowing a node pool to scale down to 0 nodes / zone is probably not the best practice moving forward, but we also don't necessarily want to keep a node running in each zone all the time.

This PR uses the regional `total_min/max_count` fields to control the min / max nodes across the entire region, while using `location_policy   = "BALANCED"` to ensure that nodes are evenly balanced across the zones