### PR TITLE
Add Datadog integration with OTEL collector support

### DIFF
--- a/datadog.tf
+++ b/datadog.tf
@@ -1,0 +1,67 @@
+resource "kubectl_manifest" "monitoring_ns" {
+  count     = var.datadog_api_key != "" ? 1 : 0
+  yaml_body = <<-YAML
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      name: monitoring
+    name: monitoring
+  spec:
+    finalizers:
+    - kubernetes
+  YAML
+
+  depends_on = [
+    module.gke,
+  ]
+}
+
+resource "kubectl_manifest" "datadog_secret" {
+  count     = var.datadog_api_key != "" ? 1 : 0
+  yaml_body = <<-YAML
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: datadog-secret
+    namespace: monitoring
+  type: Opaque
+  stringData:
+    api-key: ${var.datadog_api_key}
+  YAML
+
+  depends_on = [
+    kubectl_manifest.monitoring_ns,
+  ]
+}
+
+resource "helm_release" "datadog" {
+  count            = var.datadog_api_key != "" ? 1 : 0
+  name             = "datadog"
+  repository       = "https://helm.datadoghq.com"
+  chart            = "datadog"
+  version          = "3.133.0"
+  namespace        = "monitoring"
+  create_namespace = false
+  wait             = false
+
+  values = [
+    "${file("values/datadog.yaml")}",
+    <<-EOT
+    datadog:
+      site: ${var.datadog_site}
+    EOT
+  ]
+
+  depends_on = [
+    kubectl_manifest.datadog_secret,
+  ]
+}
+
+locals {
+  otel_env_vars = {
+    env = {
+      OTEL_EXPORTER_OTLP_ENDPOINT = "http://datadog.monitoring.svc.cluster.local:4318"
+    }
+  }
+}

--- a/gke.tf
+++ b/gke.tf
@@ -3,65 +3,65 @@ module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   version = "~> 38.0"
 
-  project_id                = var.project_id
-  name                      = var.cluster_name
-  regional                  = true
-  region                    = var.region
-  network                   = module.network.network_name
-  subnetwork                = var.subnet_name
-  ip_range_pods             = var.pods_cidr_name
-  ip_range_services         = var.services_cidr_name
-  create_service_account    = true
-  enable_private_endpoint   = false
-  enable_private_nodes      = true
+  project_id                  = var.project_id
+  name                        = var.cluster_name
+  regional                    = true
+  region                      = var.region
+  network                     = module.network.network_name
+  subnetwork                  = var.subnet_name
+  ip_range_pods               = var.pods_cidr_name
+  ip_range_services           = var.services_cidr_name
+  create_service_account      = true
+  enable_private_endpoint     = false
+  enable_private_nodes        = true
   enable_intranode_visibility = true
-  enable_shielded_nodes     = true
-  default_max_pods_per_node = 20
-  remove_default_node_pool  = true
-  deletion_protection       = var.deletion_protection
+  enable_shielded_nodes       = true
+  default_max_pods_per_node   = 20
+  remove_default_node_pool    = true
+  deletion_protection         = var.deletion_protection
 
   node_pools = concat([
     {
-      name                = "reducto-primary-node-pool"
-      machine_type        = var.primary_machine_type
-      min_count           = 1
-      max_count           = 100
-      local_ssd_count     = 1
-      disk_size_gb        = 100
-      disk_type           = "pd-ssd"
-      auto_repair         = true
-      auto_upgrade        = true
-      preemptible         = false
-      max_pods_per_node   = 20
-      enable_secure_boot  = true
+      name               = "reducto-primary-node-pool"
+      machine_type       = var.primary_machine_type
+      min_count          = 1
+      max_count          = 100
+      local_ssd_count    = 1
+      disk_size_gb       = 100
+      disk_type          = "pd-ssd"
+      auto_repair        = true
+      auto_upgrade       = true
+      preemptible        = false
+      max_pods_per_node  = 20
+      enable_secure_boot = true
     },
     {
-      name                = "reducto-secondary-node-pool"
-      machine_type        = var.secondary_machine_type
-      min_count           = 1
-      max_count           = 100
-      local_ssd_count     = 1
-      disk_size_gb        = 100
-      disk_type           = "pd-ssd"
-      auto_repair         = true
-      auto_upgrade        = true
-      preemptible         = false
-      max_pods_per_node   = 20
-      enable_secure_boot  = true
+      name               = "reducto-secondary-node-pool"
+      machine_type       = var.secondary_machine_type
+      min_count          = 1
+      max_count          = 100
+      local_ssd_count    = 1
+      disk_size_gb       = 100
+      disk_type          = "pd-ssd"
+      auto_repair        = true
+      auto_upgrade       = true
+      preemptible        = false
+      max_pods_per_node  = 20
+      enable_secure_boot = true
     },
     {
-      name                = "reducto-secondary-node-pool-preemptible"
-      machine_type        = var.secondary_machine_type
-      min_count           = 0
-      max_count           = 100
-      local_ssd_count     = 1
-      disk_size_gb        = 100
-      disk_type           = "pd-ssd"
-      auto_repair         = true
-      auto_upgrade        = true
-      preemptible         = true
-      max_pods_per_node   = 20
-      enable_secure_boot  = true
+      name               = "reducto-secondary-node-pool-preemptible"
+      machine_type       = var.secondary_machine_type
+      min_count          = 0
+      max_count          = 100
+      local_ssd_count    = 1
+      disk_size_gb       = 100
+      disk_type          = "pd-ssd"
+      auto_repair        = true
+      auto_upgrade       = true
+      preemptible        = true
+      max_pods_per_node  = 20
+      enable_secure_boot = true
     },
   ], var.extra_node_pools)
 

--- a/helm-release.tf
+++ b/helm-release.tf
@@ -39,6 +39,7 @@ resource "helm_release" "reducto" {
 
   values = [
     "${file("values/reducto.yaml")}",
+    var.datadog_api_key != "" ? yamlencode(local.otel_env_vars) : "",
     <<-EOT
     http:
       service:

--- a/values/datadog.yaml
+++ b/values/datadog.yaml
@@ -1,0 +1,12 @@
+datadog:
+  apiKeyExistingSecret: datadog-secret
+
+  otelCollector:
+    enabled: true
+    ports:
+      - containerPort: "4317" # default port for OpenTelemetry gRPC receiver.
+        hostPort: "4317"
+        name: otel-grpc
+      - containerPort: "4318" # default port for OpenTelemetry HTTP receiver
+        hostPort: "4318"
+        name: otel-http

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,16 @@ variable "extra_node_pools" {
 
   default = []
 }
+
+# Configuration for Datadog
+
+variable "datadog_site" {
+  description = "Datadog site"
+  default     = "us3.datadoghq.com"
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API key"
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- Add optional Datadog integration that mirrors the AWS infrastructure setup
- Creates monitoring namespace, Datadog secret, and Helm release when `datadog_api_key` is provided
- Configures OTEL collector to receive traces on ports 4317 (gRPC) and 4318 (HTTP)
- Injects `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to reducto worker/http pods

## Changes
- `datadog.tf` - New file with monitoring namespace, secret, and Datadog Helm release
- `values/datadog.yaml` - Datadog Helm chart values with OTEL collector enabled
- `variables.tf` - Added `datadog_api_key` and `datadog_site` variables
- `helm-release.tf` - Conditionally inject OTEL env vars when Datadog is configured
- `gke.tf` - Formatting only (terraform fmt)

## Usage
Set the following variables in `terraform.tfvars`:
```hcl
datadog_api_key = "your-datadog-api-key"
datadog_site    = "us3.datadoghq.com"  # optional, defaults to us3.datadoghq.com
```

## Test plan
- [ ] Verify terraform plan succeeds with and without `datadog_api_key` set
- [ ] Deploy to test cluster and verify Datadog agent pods are running
- [ ] Confirm OTEL traces from reducto pods appear in Datadog APM

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/reductoai/reducto-onprem-gcp/pull/18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
