### PR TITLE
Standard gke

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -14,6 +14,7 @@ module "gke" {
   create_service_account    = true
   enable_private_endpoint   = false
   enable_private_nodes      = true
+  enable_cost_allocation    = true
   default_max_pods_per_node = 20
   remove_default_node_pool  = true
   deletion_protection       = var.deletion_protection
@@ -35,7 +36,7 @@ module "gke" {
     {
       name              = "reducto-secondary-node-pool"
       machine_type      = var.secondary_machine_type
-      min_count         = 1
+      min_count         = 0
       max_count         = 100
       local_ssd_count   = 1
       disk_size_gb      = 100

--- a/gke.tf
+++ b/gke.tf
@@ -23,8 +23,9 @@ module "gke" {
     {
       name              = "reducto-primary-node-pool"
       machine_type      = var.primary_machine_type
-      min_count         = 1
-      max_count         = 100
+      total_min_count   = 2
+      total_max_count   = 100
+      location_policy   = "BALANCED"
       local_ssd_count   = 1
       disk_size_gb      = 100
       disk_type         = "pd-ssd"
@@ -36,8 +37,9 @@ module "gke" {
     {
       name              = "reducto-secondary-node-pool"
       machine_type      = var.secondary_machine_type
-      min_count         = 0
-      max_count         = 100
+      total_min_count   = 1
+      total_max_count   = 100
+      location_policy   = "BALANCED"
       local_ssd_count   = 1
       disk_size_gb      = 100
       disk_type         = "pd-ssd"
@@ -49,8 +51,9 @@ module "gke" {
     {
       name              = "reducto-secondary-node-pool-preemptible"
       machine_type      = var.secondary_machine_type
-      min_count         = 0
-      max_count         = 100
+      total_min_count   = 0
+      total_max_count   = 100
+      location_policy   = "BALANCED"
       local_ssd_count   = 1
       disk_size_gb      = 100
       disk_type         = "pd-ssd"

--- a/helm-release.tf
+++ b/helm-release.tf
@@ -38,7 +38,9 @@ resource "helm_release" "reducto" {
   wait    = false
 
   values = [
-    "${file("values/reducto.yaml")}",
+    templatefile("${path.module}/values/reducto.yaml.tftpl", {
+      min_replica_count = var.reducto_worker_min_replica_count
+    }),
     <<-EOT
     http:
       service:

--- a/keda.tf
+++ b/keda.tf
@@ -7,7 +7,7 @@ resource "helm_release" "keda" {
   create_namespace = true
 
   values = [
-    "${file("values/keda.yaml")}"
+    file("${path.module}/values/keda.yaml")
   ]
 
   depends_on = [

--- a/values/keda.yaml
+++ b/values/keda.yaml
@@ -6,39 +6,39 @@ operator:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app
-            operator: In
-            values:
-            - keda-operator
-        topologyKey: "topology.kubernetes.io/zone"
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - keda-operator
+          topologyKey: "topology.kubernetes.io/zone"
 
 metricsServer:
   replicaCount: 2
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app
-            operator: In
-            values:
-            - keda-operator-metrics-apiserver
-        topologyKey: "topology.kubernetes.io/zone"
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - keda-operator-metrics-apiserver
+          topologyKey: "topology.kubernetes.io/zone"
 
 webhooks:
   replicaCount: 2
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app
-            operator: In
-            values:
-            - keda-admission-webhooks
-        topologyKey: "topology.kubernetes.io/zone"
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - keda-admission-webhooks
+          topologyKey: "topology.kubernetes.io/zone"
 
 resources:
   # -- Manage [resource request & limits] of KEDA operator pod

--- a/values/reducto.yaml.tftpl
+++ b/values/reducto.yaml.tftpl
@@ -21,7 +21,7 @@ worker:
     enabled: true
   kedaScaler: true
   scaling:
-    minReplicaCount: 5
+    minReplicaCount: ${min_replica_count}
     maxReplicaCount: 100
 
   resources:

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,9 @@ variable "extra_node_pools" {
 
   default = []
 }
+
+variable "reducto_worker_min_replica_count" {
+  description = "The minimum number of reducto workers to maintain via KEDA"
+  type = number
+  default = 5
+}


### PR DESCRIPTION
the helm-release.tf & keda.tf files were trying to grab the value files from the tf root directory, meaning we had to add our own copies of these values everywhere in our code base, probably don't need to do that.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/reductoai/reducto-onprem-gcp/pull/19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
