### PR TITLE
Fix file paths to use path.module for remote module compatibility

### DIFF
--- a/datadog.tf
+++ b/datadog.tf
@@ -46,7 +46,7 @@ resource "helm_release" "datadog" {
   wait             = false
 
   values = [
-    "${file("values/datadog.yaml")}",
+    "${file("${path.module}/values/datadog.yaml")}",
     <<-EOT
     datadog:
       site: ${var.datadog_site}

--- a/helm-release.tf
+++ b/helm-release.tf
@@ -38,7 +38,7 @@ resource "helm_release" "reducto" {
   wait    = false
 
   values = [
-    "${file("values/reducto.yaml")}",
+    "${file("${path.module}/values/reducto.yaml")}",
     var.datadog_api_key != "" ? yamlencode(local.otel_env_vars) : "",
     <<-EOT
     http:

--- a/keda.tf
+++ b/keda.tf
@@ -7,7 +7,7 @@ resource "helm_release" "keda" {
   create_namespace = true
 
   values = [
-    "${file("values/keda.yaml")}"
+    "${file("${path.module}/values/keda.yaml")}"
   ]
 
   depends_on = [


### PR DESCRIPTION
## Summary

- Fix `file()` calls to use `${path.module}` prefix so paths resolve correctly when used as a remote Terraform module
- Affects `datadog.tf`, `keda.tf`, and `helm-release.tf`

## Problem

When this repository is used as a remote Terraform module:
```hcl
module "reducto" {
  source = "github.com/reductoai/reducto-onprem-gcp"
}
```

Relative file paths like `file("values/datadog.yaml")` fail because they resolve relative to the caller's working directory, not the module's location.

## Changes

| File | Before | After |
|------|--------|-------|
| `datadog.tf` | `file("values/datadog.yaml")` | `file("${path.module}/values/datadog.yaml")` |
| `keda.tf` | `file("values/keda.yaml")` | `file("${path.module}/values/keda.yaml")` |
| `helm-release.tf` | `file("values/reducto.yaml")` | `file("${path.module}/values/reducto.yaml")` |

## Test plan

- [ ] Verify `terraform plan` succeeds when running from repo root
- [ ] Verify module works when sourced remotely from another Terraform configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/reductoai/reducto-onprem-gcp/pull/20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
