### PR TITLE
Add required zones variable to work around AI zone bug

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -7,6 +7,7 @@ module "gke" {
   name                      = var.cluster_name
   regional                  = true
   region                    = var.region
+  zones                     = var.zones
   network                   = module.network.network_name
   subnetwork                = var.subnet_name
   ip_range_pods             = var.pods_cidr_name

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,11 @@ variable "region" {
   default     = "us-west1"
 }
 
+variable "zones" {
+  type        = list(string)
+  description = "Explicit list of zones for the GKE cluster (required). See https://github.com/hashicorp/terraform-provider-google/issues/25914"
+}
+
 variable "network_name" {
   type        = string
   description = "The name of the network to create"


### PR DESCRIPTION
GCP now returns AI zones (e.g., us-south1-ai1b) from google_compute_zones. 

One workaround is to pass on an explicit zone argument to GKE.

Example:
  zones = ["us-west1-a", "us-west1-b", "us-west1-c"]

See: https://github.com/hashicorp/terraform-provider-google/issues/25914
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/reductoai/reducto-onprem-gcp/pull/22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
