### PR TITLE
Add google artifact registry provisioning

### DIFF
--- a/artifact-registry.tf
+++ b/artifact-registry.tf
@@ -21,3 +21,17 @@ resource "google_artifact_registry_repository_iam_member" "gke_nodes_pull" {
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${module.gke.service_account}"
 }
+
+resource "google_service_account" "artifact_registry_push" {
+  account_id   = var.artifact_registry_push_service_account_id
+  display_name = "Artifact Registry image push"
+  project      = var.project_id
+}
+
+resource "google_artifact_registry_repository_iam_member" "push_writer" {
+  project    = var.project_id
+  location   = google_artifact_registry_repository.main.location
+  repository = google_artifact_registry_repository.main.repository_id
+  role       = "roles/artifactregistry.writer"
+  member     = google_service_account.artifact_registry_push.member
+}

--- a/artifact-registry.tf
+++ b/artifact-registry.tf
@@ -1,0 +1,23 @@
+locals {
+  artifact_registry_location = var.artifact_registry_location != "" ? var.artifact_registry_location : var.region
+}
+
+resource "google_artifact_registry_repository" "main" {
+  location      = local.artifact_registry_location
+  repository_id = var.artifact_registry_repository_id
+  description   = "Docker images for Reducto on GCP"
+  format        = "DOCKER"
+  project       = var.project_id
+
+  depends_on = [google_project_service.services["artifactregistry.googleapis.com"]]
+}
+
+# Default node service account (module.gke with create_service_account = true) must
+# be able to pull images referenced by workloads on the nodes.
+resource "google_artifact_registry_repository_iam_member" "gke_nodes_pull" {
+  project    = var.project_id
+  location   = google_artifact_registry_repository.main.location
+  repository = google_artifact_registry_repository.main.repository_id
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${module.gke.service_account}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,3 +51,8 @@ output "artifact_registry_docker_url" {
   description = "Docker registry hostname for docker push/pull (REGION-docker.pkg.dev/PROJECT/REPO)"
   value       = "${google_artifact_registry_repository.main.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.main.repository_id}"
 }
+
+output "artifact_registry_push_service_account_email" {
+  description = "Service account email for pushing images to Artifact Registry (use with Workload Identity Federation, gcloud auth activate-service-account, or a manually created key)"
+  value       = google_service_account.artifact_registry_push.email
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,3 +36,18 @@ output "vpc_network_name" {
   description = "The name of the VPC network created for Reducto"
   value       = module.network.network_name
 }
+
+output "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID"
+  value       = google_artifact_registry_repository.main.repository_id
+}
+
+output "artifact_registry_location" {
+  description = "Region where the Artifact Registry repository is hosted"
+  value       = google_artifact_registry_repository.main.location
+}
+
+output "artifact_registry_docker_url" {
+  description = "Docker registry hostname for docker push/pull (REGION-docker.pkg.dev/PROJECT/REPO)"
+  value       = "${google_artifact_registry_repository.main.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.main.repository_id}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,12 @@ variable "artifact_registry_location" {
   default     = ""
 }
 
+variable "artifact_registry_push_service_account_id" {
+  type        = string
+  description = "Account ID for the service account used to push images to Artifact Registry (not used by GKE nodes)"
+  default     = "reducto-gar-push"
+}
+
 variable "cluster_name" {
   type        = string
   description = "The name of the cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,21 @@ variable "enable_apis" {
     "apikeys.googleapis.com",
     # for Google Cloud Vision
     "vision.googleapis.com",
+    # for Artifact Registry (container images)
+    "artifactregistry.googleapis.com",
   ]
+}
+
+variable "artifact_registry_repository_id" {
+  type        = string
+  description = "Repository ID for the Google Artifact Registry (Docker format). Must match ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$"
+  default     = "reducto-images"
+}
+
+variable "artifact_registry_location" {
+  type        = string
+  description = "GCP region for the Artifact Registry repository (often the same as var.region)"
+  default     = ""
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
- Provisions a GAR registry and adds read permissions for the service account assigned to reducto nodes
- Provisions a separate service account with write permissions for the same GAR registry. No service account key is created in Terraform. Authenticate with WIF, gcloud auth activate-service-account + a key created outside Terraform, or impersonation, as preferred.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/reductoai/reducto-onprem-gcp/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
